### PR TITLE
Mremap fix

### DIFF
--- a/umvu/src/vu_mmap_table.c
+++ b/umvu/src/vu_mmap_table.c
@@ -124,12 +124,12 @@ void vu_mmap_munmap(uintptr_t addr, size_t length) {
 void vu_mmap_mremap(uintptr_t addr, size_t length, uintptr_t newaddr, size_t newlength) {
 	struct vu_mmap_area_t **scan;
 	struct vu_mmap_area_t *this;
-  fatal(vu_mmap);
+	fatal(vu_mmap);
 	for (scan = &vu_mmap->area_list_head; *scan != NULL && (*scan)->addr < addr;
 			scan = &((*scan)->next))
-    ;
+		;
 	this = *scan;
-	if (this->addr == addr && this->length == length) {
+	if (this && this->addr == addr && this->length == length) {
 		this->addr = newaddr;
 		this->length = newlength;
 		for (scan = &vu_mmap->area_list_head; *scan != NULL && (*scan)->addr < newaddr;

--- a/umvu/src/vu_wrap_mmap.c
+++ b/umvu/src/vu_wrap_mmap.c
@@ -91,8 +91,8 @@ void wo_mremap(struct vuht_entry_t *ht, struct syscall_descriptor_t *sd) {
 	uintptr_t newaddr = sd->orig_ret_value;
 	if (newaddr != (uintptr_t) -1) {
 		uintptr_t oldaddr = sd->syscall_args[0];
-    size_t oldlength = sd->syscall_args[1];
-		size_t newlength = sd->syscall_args[1];
+		size_t oldlength = sd->syscall_args[1];
+		size_t newlength = sd->syscall_args[2];
 		vu_mmap_mremap(oldaddr, oldlength, newaddr, newlength);
 	}
 	sd->ret_value = sd->orig_ret_value;


### PR DESCRIPTION
Just a small fix for the mremap() wrapping. I came across this because of a segfault while trying to run tilix (terminal emulator).