### PR TITLE
umvu: add partial arm64 support

### DIFF
--- a/umvu/include/umvu_peekpoke.h
+++ b/umvu/include/umvu_peekpoke.h
@@ -17,12 +17,33 @@ typedef struct user_regs_struct arch_regs_struct;
 
 #elif defined(__riscv_xlen) && __riscv_xlen == 64
 
-#include<asm/ptrace.h>
+#include <asm/ptrace.h>
 
 #define SYSCALL_ARG_NR 6
 typedef unsigned long int syscall_arg_t;
 #define SYSCALL_INSTRUCTION_LEN 4
 typedef struct user_regs_struct arch_regs_struct;
+
+#elif defined(__aarch64__)
+
+#include <asm/ptrace.h>
+#define SYSCALL_ARG_NR 6
+typedef unsigned long int syscall_arg_t;
+#define SYSCALL_INSTRUCTION_LEN 4
+struct arch_regs_struct_full {
+	union {
+		struct user_regs_struct user_regs;
+		struct {
+			unsigned long regs[31];
+			unsigned long sp;
+			unsigned long pc;
+			unsigned long pstate;
+		};
+	};
+	int syscallno;
+};
+typedef struct arch_regs_struct_full arch_regs_struct;
+//typedef struct user_regs_struct arch_regs_struct;
 
 #else
 


### PR DESCRIPTION
Added partial arm64 support. Now at least `bash`, `vuname` and other normal apps worked.
```
umvu -l 7 -s 7 -S busybox ash
Purelibc found: nested virtualization enabled
~ $ vuname -a
Linux ArchLinux-ACE3-Keqing 5.15.123-Fish4terrisa-MSDSM+ #1 SMP PREEMPT Mon Apr 28 18:14:32 UTC 2025 aarch64 GNU/Linux/VUOS 1243241
```
VUOS modules arent working:
```
umvu -l 7 -s 7 -S busybox ash
Purelibc found: nested virtualization enabled
~ $ vu_insmod vudev
vudev: Invalid argument
```
and I really cannot figure out why. Also I have to set disable_seccomp_optimization(-S), otherwise I'll get:
```
umvu -l 7 -s 7 true
Purelibc found: nested virtualization enabled
munmap_chunk(): invalid pointer
```

I know nearly nothing about ptrace and vuos, so probably it contains bugs and implemention errors.
Hope this may help vuos start to support arm64 `:)`